### PR TITLE
Add indie auth micropub token endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="me" href="mailto:tamiolaf@gmail.com" />
     <link rel="authorization_endpoint" href="https://indieauth.com/auth">
+    <link rel="token_endpoint" href="https://tokens.indieauth.com/token">
 
 
 


### PR DESCRIPTION
Following instructions to add micropub to my site. This PR adds a token endpoint using indie auth.

More Info on auth [here](https://tokens.indieauth.com/) and on micropub [here](https://micropub.rocks/endpoints/new)